### PR TITLE
Do not delete zones. Mark them as "not enabled" instead.

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -56,7 +56,9 @@ def post_zone(data):
 @app.route('/v1/zones/<id>', methods=['DELETE'])
 @api_response()
 def delete_zone(id):
-    Zone.objects.get(pk=id).delete()
+    zone = Zone.objects.get(pk=id)
+    zone.enabled = False
+    zone.save()
 
 
 @app.route('/v1/tracking-data/<tracking_id>', methods=['GET'])

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,11 @@
+class DataTypes(object):
+    enter = 'enter'
+    leave = 'leave'
+    track = 'track'
+
+
+DATA_TYPES = (
+    (DataTypes.enter, DataTypes.enter),
+    (DataTypes.leave, DataTypes.leave),
+    (DataTypes.track, DataTypes.track),
+)

--- a/src/models.py
+++ b/src/models.py
@@ -1,10 +1,15 @@
 from mongoengine import (
-    Document, StringField, FloatField, IntField, DateTimeField, BooleanField)
+    Document, ObjectIdField, StringField, FloatField, IntField, DateTimeField,
+    BooleanField)
 from datetime import datetime
+
+from constants import DATA_TYPES
 
 
 class Tracking(Document):
     tracking_id = StringField(required=True)
+    data_type = StringField(max_length=5, choices=DATA_TYPES, required=True)
+    zone_id = ObjectIdField(required=True)
     lat = FloatField(required=True)
     lon = FloatField(required=True)
     tracking_timestamp = IntField(required=True)
@@ -20,6 +25,8 @@ class Tracking(Document):
         return {
             'id': str(self.id),
             'tracking_id': self.tracking_id,
+            'data_type': self.data_type,
+            'zone_id': str(self.zone_id),
             'tracking_timestamp': self.tracking_timestamp,
             'created_at': self.created_at,
             'lon': self.lon,
@@ -35,6 +42,7 @@ class Zone(Document):
     lon = FloatField(required=True)
     radius = IntField(required=True)
     enabled = BooleanField(default=True)
+    created_at = DateTimeField(default=datetime.now)
 
     def as_dict(self):
         data = self.to_mongo()

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -3,6 +3,10 @@ from schema import Schema, And, Or, Use
 tracking_base = {
     'tracking_id': And(
         basestring, len, error='tracking_id should be non-empty string'),
+    'zone_id': And(
+        basestring, len, error='zone_id should be non-empty string'),
+    'data_type': And(
+        basestring, len, error='data_type should be non-empty string'),
     'tracking_timestamp': Use(
         int, error='tracking_timestamp should be integer'),
     'lat': Or(int, float, error='lat should be either int or float'),


### PR DESCRIPTION
Closes: #7 #6 

1. Do not delete zones. Mark them as "not enabled" instead.
2. Add "data_type" and "zone_id" fields to tracking data.